### PR TITLE
Bug fix

### DIFF
--- a/testCases.c
+++ b/testCases.c
@@ -379,18 +379,17 @@
 		char *str2 = "world";
 
 		swap(&str1, &str2);
-		char *actual[] = {};
+		char *actual[2]; // Specify size 2
 		actual[0] = str1;
 		actual[1] = str2;
 
-		char *expected[] = {};
+		char *expected[2]; // Specify size 2
 		expected[0] = "world";
 		expected[1] = "hello";
 
 		int i;
-		for (i=0;i<2;i++)
+		for (i = 0; i < 2; i++)
 			CuAssertStrEquals(tc, expected[i], actual[i]);
-
 	}
 
 	void TestQ2_swap2(CuTest *tc)
@@ -399,18 +398,17 @@
 		char *str2 = "ece";
 
 		swap(&str1, &str2);
-		char *actual[] = {};
+		char *actual[2]; // Specify size 2
 		actual[0] = str1;
 		actual[1] = str2;
 
-		char *expected[] = {};
+		char *expected[2]; // Specify size 2
 		expected[0] = "ece";
 		expected[1] = "mcmaster";
 
 		int i;
-		for (i=0;i<2;i++)
+		for (i = 0; i < 2; i++)
 			CuAssertStrEquals(tc, expected[i], actual[i]);
-
 	}
 
 	void TestQ2_sortbubble1(CuTest *tc) {


### PR DESCRIPTION
Fixed: 

- By declaring `actual` and `expected` as arrays of size 2 (`char *actual[2];` and `char *expected[2];`), you ensure that there is enough space allocated to store the two pointers (`str1` and `str2`) in each test case. This will resolve the array index out of bounds errors you were encountering.

```
testCases.c:384:9: error: Array 'actual[1]' accessed at index 1, which is out of bounds. [arrayIndexOutOfBounds]
  actual[1] = str2;
        ^
testCases.c:388:11: error: Array 'expected[1]' accessed at index 1, which is out of bounds. [arrayIndexOutOfBounds]
  expected[1] = "hello";
          ^
testCases.c:392:4: error: Array 'expected[1]' accessed at index 1, which is out of bounds. [arrayIndexOutOfBounds]
   CuAssertStrEquals(tc, expected[i], actual[i]);
   ^
testCases.c:391:13: note: Assuming that condition 'i<2' is not redundant
  for (i=0;i<2;i++)
            ^
testCases.c:392:4: note: Array index out of bounds
   CuAssertStrEquals(tc, expected[i], actual[i]);
   ^
testCases.c:392:4: error: Array 'actual[1]' accessed at index 1, which is out of bounds. [arrayIndexOutOfBounds]
   CuAssertStrEquals(tc, expected[i], actual[i]);
   ^
testCases.c:391:13: note: Assuming that condition 'i<2' is not redundant
  for (i=0;i<2;i++)
            ^
testCases.c:392:4: note: Array index out of bounds
   CuAssertStrEquals(tc, expected[i], actual[i]);
   ^
testCases.c:404:9: error: Array 'actual[1]' accessed at index 1, which is out of bounds. [arrayIndexOutOfBounds]
  actual[1] = str2;
        ^
testCases.c:408:11: error: Array 'expected[1]' accessed at index 1, which is out of bounds. [arrayIndexOutOfBounds]
  expected[1] = "mcmaster";
          ^
testCases.c:412:4: error: Array 'expected[1]' accessed at index 1, which is out of bounds. [arrayIndexOutOfBounds]
   CuAssertStrEquals(tc, expected[i], actual[i]);
   ^
testCases.c:411:13: note: Assuming that condition 'i<2' is not redundant
  for (i=0;i<2;i++)
            ^
testCases.c:412:4: note: Array index out of bounds
   CuAssertStrEquals(tc, expected[i], actual[i]);
   ^
testCases.c:412:4: error: Array 'actual[1]' accessed at index 1, which is out of bounds. [arrayIndexOutOfBounds]
   CuAssertStrEquals(tc, expected[i], actual[i]);
   ^
testCases.c:411:13: note: Assuming that condition 'i<2' is not redundant
  for (i=0;i<2;i++)
            ^
testCases.c:412:4: note: Array index out of bounds
   CuAssertStrEquals(tc, expected[i], actual[i]);
   ^
```